### PR TITLE
Handling bad request status

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
@@ -152,6 +153,13 @@ func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 					resp.Body = streams
 				}
 				return resp, nil
+			}
+			if resp.StatusCode == http.StatusBadRequest {
+				t, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					return resp, err
+				}
+				return resp, fmt.Errorf("Bad request %s", string(t))
 			}
 			if !c.config.Retryable.RetryResponse(resp) {
 				return resp, nil

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -433,7 +433,6 @@ func TestBadRequestCall(t *testing.T) {
 	}
 	req, err := http.NewRequest(http.MethodPost, "/test", strings.NewReader("{"))
 	assert.NoError(err)
-	t.Log("URL>>", req.URL)
 	resp, err := client.Do(req)
 	assert.Error(err)
 	assert.NotNil(resp)


### PR DESCRIPTION
Handling bad request status.

httpclient was retrying after bad request status.